### PR TITLE
fix test script

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using LinearAlgebra
-import .SkewLinearAlgebra as SLA
+import SkewLinearAlgebra as SLA
 using Test
 
 @testset "SkewLinearAlgebra.jl" begin


### PR DESCRIPTION
For package testing, you don't `import .Foo`, you `import Foo`.  The former is only used for modules that have *already* been defined in the current namespace (e.g. for modules whose definitions you loaded with `include`).  The latter is used for loading packages from the Julia load path, which should always be the case for packages that you have installed properly.