### PR TITLE
logabspfaffian fixes

### DIFF
--- a/src/pfaffian.jl
+++ b/src/pfaffian.jl
@@ -61,11 +61,9 @@ pfaffian(A::AbstractMatrix{<:BigInt}) = pfaffian!(copy(A))
 
 function _pfaffian!(A::SkewHermitian{<:Real})
     n = size(A,1)
-    if n%2 == 1
-        return convert(eltype(A.data), 0)
-    end 
-    H = hessenberg(A)
-    pf = convert(eltype(A.data), 1)
+    isodd(n) && return zero(eltype(A))
+    H = hessenberg!(A)
+    pf = one(eltype(A))
     T = H.H
     for i=1:2:n-1
         pf *= -T.ev[i]
@@ -91,13 +89,11 @@ end
 
 function _logabspfaffian!(A::SkewHermitian{<:Real})
     n = size(A, 1)
-    if n%2 == 1
-        throw(ArgumentError("Pfaffian of singular matrix is zero, log(0) is undefined"))
-    end 
-    H = hessenberg(A)
-    logpf = convert(eltype(A.data), 1)
+    isodd(n) && return convert(eltype(A), -Inf), zero(eltype(A))
+    H = hessenberg!(A)
+    logpf = zero(eltype(H))
     T = H.H
-    sgn = one(eltype(A.data))
+    sgn = one(eltype(H))
     for i=1:2:n-1
         logpf += log(abs(T.ev[i]))
         sgn *= sign(T.ev[i])

--- a/src/pfaffian.jl
+++ b/src/pfaffian.jl
@@ -96,7 +96,7 @@ function _logabspfaffian!(A::SkewHermitian{<:Real})
     sgn = one(eltype(H))
     for i=1:2:n-1
         logpf += log(abs(T.ev[i]))
-        sgn *= sign(T.ev[i])
+        sgn *= sign(-T.ev[i])
     end
     return logpf, sgn
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -342,6 +342,8 @@ end
             @test SLA.pfaffian(Abig)^2 == det(Abig)
         end
         @test Float64(SLA.pfaffian(Abig)^2) ≈ (iseven(n) ? det(Float64.(A)) : 0.0)
+        logpf, sign = SLA.logpfaffian(A)
+        @test SLA.pfaffian(A) ≈ sign * exp(logpf)
     end
     # issue #49
     @test SLA.pfaffian(big.([0 14 7 -10 0 10 0 -11; -14 0 -10 7 13 -9 -12 -13; -7 10 0 -4 6 -17 -1 18; 10 -7 4 0 -2 -4 0 11; 0 -13 -6 2 0 -8 -18 17; -10 9 17 4 8 0 -8 12; 0 12 1 0 18 8 0 0; 11 13 -18 -11 -17 -12 0 0])) == -119000

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -342,7 +342,7 @@ end
             @test SLA.pfaffian(Abig)^2 == det(Abig)
         end
         @test Float64(SLA.pfaffian(Abig)^2) ≈ (iseven(n) ? det(Float64.(A)) : 0.0)
-        logpf, sign = SLA.logpfaffian(A)
+        logpf, sign = SLA.logabspfaffian(A)
         @test SLA.pfaffian(A) ≈ sign * exp(logpf)
     end
     # issue #49


### PR DESCRIPTION
Some fixes: `log(0.0) == -Inf`, not undefined, and you should start your sum of the logs with zero, not one.   Also, in `logabspfaffian!` and `pfaffian!` you should presumably use the in-place `hessenberg!`.

Also added a test for `logabspfaffian`.

Also fixed another bug in the sign calculation (there was a missing minus sign).