### PR TITLE
enable coverage and docs in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,8 +66,35 @@ jobs:
           git config --global user.name Tester
           git config --global user.email te@st.er
       - uses: julia-actions/julia-runtest@latest
-      #- uses: julia-actions/julia-processcoverage@v1
-      #- uses: codecov/codecov-action@v2
-      #  with:
-      #    files: lcov.info
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v2
+        with:
+          files: lcov.info
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - run: |
+          git config --global user.name name
+          git config --global user.email email
+          git config --global github.user username
+      - run: |
+          julia --project=docs -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
+      - run: |
+          julia --project=docs -e '
+            using Documenter: doctest
+            using PkgTemplates
+            doctest(PkgTemplates)'
+      - run: julia --project=docs docs/make.jl
+        env:
+          JULIA_PKG_SERVER: ""
+          GITHUB_TOKEN: ${{ secrets.GITH
 


### PR DESCRIPTION
Enable codecov and documentation building in CI (copied from https://github.com/invenia/PkgTemplates.jl/blob/bdb157ef8440dc493644c1915e6488c5eaad5204/.github/workflows/CI.yml), for #36 and #68.