### PR TITLE
improve tridiag and jmatrix display

### DIFF
--- a/src/jmatrix.jl
+++ b/src/jmatrix.jl
@@ -18,6 +18,8 @@ struct JMatrix{T<:Real, SGN} <: AbstractMatrix{T}
     end
 end
 
+JMatrix(n::Integer) = JMatrix{Int8,+1}(n) # default constructor using narrowest integer type
+
 Base.size(J::JMatrix) = (J.n, J.n)
 Base.size(J::JMatrix, n::Integer) = n in (1,2) ? J.n : 1
 
@@ -105,4 +107,9 @@ function LA.diag(J::JMatrix{T,SGN}, k::Integer=0) where {T,SGN}
         v[1:2:J.n-1] .= -SGN
     end
     return v
+end
+
+# show a "⋅" for structural zeros when printing
+function Base.replace_in_print_matrix(A::JMatrix, i::Integer, j::Integer, s::AbstractString)
+    (i == j+1 && iseven(i)) || (i+1 == j && iseven(j)) ? s : Base.replace_with_centered_mark(s)
 end

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -641,6 +641,10 @@ end
 #det(A::SkewHermTridiagonal; shift::Number=false) = det_usmani(A.ev, A.dv, A.ev, shift)
 #logabsdet(A::SkewHermTridiagonal; shift::Number=false) = logabsdet(ldlt(A; shift=shift))
 
+# show a "⋅" for structural zeros when printing
+function Base.replace_in_print_matrix(A::SkewHermTridiagonal, i::Integer, j::Integer, s::AbstractString)
+    i==j-1 || i==j+1 ? s : Base.replace_with_centered_mark(s)
+end
 
 Base.@propagate_inbounds function Base.getindex(A::SkewHermTridiagonal{T}, i::Integer, j::Integer) where T
 

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -643,7 +643,7 @@ end
 
 # show a "⋅" for structural zeros when printing
 function Base.replace_in_print_matrix(A::SkewHermTridiagonal, i::Integer, j::Integer, s::AbstractString)
-    i==j-1 || i==j+1 ? s : Base.replace_with_centered_mark(s)
+    i==j-1 || i==j+1 || (A.dvim !== nothing && i==j) ? s : Base.replace_with_centered_mark(s)
 end
 
 Base.@propagate_inbounds function Base.getindex(A::SkewHermTridiagonal{T}, i::Integer, j::Integer) where T

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -328,6 +328,9 @@ end
     B = SLA.SkewHermTridiagonal([3,4,5])
     @test B == [0 -3 0 0; 3 0 -4 0; 0 4 0 -5; 0 0 5 0]
     @test repr("text/plain", B) == "4×4 SkewLinearAlgebra.SkewHermTridiagonal{$Int, Vector{$Int}, Nothing}:\n ⋅  -3   ⋅   ⋅\n 3   ⋅  -4   ⋅\n ⋅   4   ⋅  -5\n ⋅   ⋅   5   ⋅"
+    C = SLA.SkewHermTridiagonal(complex.([3,4,5]), [6,7,8,9])
+    @test C == [6im -3 0 0; 3 7im -4 0; 0 4 8im -5; 0 0 5 9im]
+    @test repr("text/plain", C) == "4×4 SkewLinearAlgebra.SkewHermTridiagonal{Complex{$Int}, Vector{Complex{$Int}}, Vector{$Int}}:\n 0+6im  -3+0im     ⋅       ⋅  \n 3+0im   0+7im  -4+0im     ⋅  \n   ⋅     4+0im   0+8im  -5+0im\n   ⋅       ⋅     5+0im   0+9im"
 end
 
 @testset "pfaffian.jl" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -290,9 +290,7 @@ end
         end
         B = Matrix(A)
         @test tr(A) ≈ tr(B)
-        B = copy(A)
-        @test B == A
-        B = Matrix(A)
+        @test B == copy(A) == A
         yb = rand(T, 1, n)
         if !iszero(det(Tridiagonal(A)))
             @test A \ x ≈ B \ x
@@ -319,16 +317,17 @@ end
         Svd = svd(A)
         @test Svd.U * Diagonal(Svd.S) * Svd.Vt ≈ B
         @test svdvals(A) ≈ svdvals(B)
+        for f in (real, imag)
+            @test Matrix(f(A)) == f(B)
+        end
 
         A[2,1] = 2
-        @test A[2,1] === T(2)
-        B = SLA.SkewHermTridiagonal([3,4,5])
-        @test B == [0 -3 0 0; 3 0 -4 0; 0 4 0 -5; 0 0 5 0]
-        #@test repr("text/plain", B) == "4×4 SkewLinearAlgebra.SkewHermTridiagonal{$Int, Vector{$Int}}:\n 0  -3   ⋅   ⋅\n 3   0  -4   ⋅\n ⋅   4   0  -5\n ⋅   ⋅   5   0"
-        for f in (real, imag)
-            @test Matrix(f(A)) == f(Matrix(A))
-        end
+        @test A[2,1] === T(2) === -A[1,2]'
     end
+
+    B = SLA.SkewHermTridiagonal([3,4,5])
+    @test B == [0 -3 0 0; 3 0 -4 0; 0 4 0 -5; 0 0 5 0]
+    @test repr("text/plain", B) == "4×4 SkewLinearAlgebra.SkewHermTridiagonal{$Int, Vector{$Int}, Nothing}:\n ⋅  -3   ⋅   ⋅\n 3   ⋅  -4   ⋅\n ⋅   4   ⋅  -5\n ⋅   ⋅   5   ⋅"
 end
 
 @testset "pfaffian.jl" begin
@@ -388,5 +387,5 @@ end
         @test iszero(tr(J))
         @test iseven(n) == det(J) ≈ det(Jtest2)
     end
+    @test repr("text/plain", SLA.JMatrix(4)) == "4×4 SkewLinearAlgebra.JMatrix{Int8, 1}:\n  ⋅  1   ⋅  ⋅\n -1  ⋅   ⋅  ⋅\n  ⋅  ⋅   ⋅  1\n  ⋅  ⋅  -1  ⋅"
 end
-


### PR DESCRIPTION
This improves the display of `SkewHermTridiagonal` and `JMatrix` to show "structural" zeros as dots in REPL display (similar to LinearAlgebra's sparse types).   This makes them more readable in the REPL:
```jl
julia> SkewHermTridiagonal([3,4,5])
4×4 SkewHermTridiagonal{Int64, Vector{Int64}, Nothing}:
 ⋅  -3   ⋅   ⋅
 3   ⋅  -4   ⋅
 ⋅   4   ⋅  -5
 ⋅   ⋅   5   ⋅

julia> JMatrix(10)
10×10 JMatrix{Int8, 1}:
  ⋅  1   ⋅  ⋅   ⋅  ⋅   ⋅  ⋅   ⋅  ⋅
 -1  ⋅   ⋅  ⋅   ⋅  ⋅   ⋅  ⋅   ⋅  ⋅
  ⋅  ⋅   ⋅  1   ⋅  ⋅   ⋅  ⋅   ⋅  ⋅
  ⋅  ⋅  -1  ⋅   ⋅  ⋅   ⋅  ⋅   ⋅  ⋅
  ⋅  ⋅   ⋅  ⋅   ⋅  1   ⋅  ⋅   ⋅  ⋅
  ⋅  ⋅   ⋅  ⋅  -1  ⋅   ⋅  ⋅   ⋅  ⋅
  ⋅  ⋅   ⋅  ⋅   ⋅  ⋅   ⋅  1   ⋅  ⋅
  ⋅  ⋅   ⋅  ⋅   ⋅  ⋅  -1  ⋅   ⋅  ⋅
  ⋅  ⋅   ⋅  ⋅   ⋅  ⋅   ⋅  ⋅   ⋅  1
  ⋅  ⋅   ⋅  ⋅   ⋅  ⋅   ⋅  ⋅  -1  ⋅
```

This was actually added in #22 for `SkewHermTridiagonal` but you removed it in without explanation (perhaps accidentally?) in #32.