### PR TITLE
improve test coverage

### DIFF
--- a/src/pfaffian.jl
+++ b/src/pfaffian.jl
@@ -58,9 +58,12 @@ exactpfaffian!(A::SkewHermitian) = _exactpfaffian!(A.data)
 exactpfaffian(A::AbstractMatrix) = exactpfaffian!(copyto!(similar(A), A))
 
 const ExactRational = Union{BigInt,Rational{BigInt}}
-pfaffian(A::SkewHermitian{<:ExactRational}) = pfaffian!(copy(A))
 pfaffian!(A::AbstractMatrix{<:ExactRational}) = exactpfaffian!(A)
 pfaffian(A::AbstractMatrix{<:ExactRational}) = pfaffian!(copy(A))
+
+# prevent method ambiguities:
+pfaffian(A::SkewHermitian{<:ExactRational}) = pfaffian!(copy(A))
+pfaffian!(A::SkewHermitian{<:ExactRational}) = exactpfaffian!(A)
 
 function _pfaffian!(A::SkewHermitian{<:Real})
     n = size(A,1)

--- a/src/pfaffian.jl
+++ b/src/pfaffian.jl
@@ -58,7 +58,7 @@ exactpfaffian!(A::SkewHermitian) = _exactpfaffian!(A.data)
 exactpfaffian(A::AbstractMatrix) = exactpfaffian!(copyto!(similar(A), A))
 
 const ExactRational = Union{BigInt,Rational{BigInt}}
-pfaffian!(A::SkewHermitian{<:ExactRational}) = _exactpfaffian!(A.data)
+pfaffian!(A::SkewHermitian{<:ExactRational}) = exactpfaffian!(A)
 pfaffian(A::SkewHermitian{<:ExactRational}) = pfaffian!(copy(A))
 pfaffian!(A::AbstractMatrix{<:ExactRational}) = exactpfaffian!(A)
 pfaffian(A::AbstractMatrix{<:ExactRational}) = pfaffian!(copy(A))

--- a/src/pfaffian.jl
+++ b/src/pfaffian.jl
@@ -58,7 +58,6 @@ exactpfaffian!(A::SkewHermitian) = _exactpfaffian!(A.data)
 exactpfaffian(A::AbstractMatrix) = exactpfaffian!(copyto!(similar(A), A))
 
 const ExactRational = Union{BigInt,Rational{BigInt}}
-pfaffian!(A::SkewHermitian{<:ExactRational}) = exactpfaffian!(A)
 pfaffian(A::SkewHermitian{<:ExactRational}) = pfaffian!(copy(A))
 pfaffian!(A::AbstractMatrix{<:ExactRational}) = exactpfaffian!(A)
 pfaffian(A::AbstractMatrix{<:ExactRational}) = pfaffian!(copy(A))


### PR DESCRIPTION
I noticed that the `exactpfaffian!(A::SkewHermitian)` method wasn't getting covered by tests.   The `pfaffian!` function should call this rather than the lower-level `_exactpfaffian!` function.

In fact, the `pfaffian!(A::SkewHermitian{<:ExactRational})` method was completely redundant with the `pfaffian!(A::AbstractMatrix{<:ExactRational}) = exactpfaffian!(A)` method.