### PR TITLE
don't check approximate equality elementwise

### DIFF
--- a/src/SkewLinearAlgebra.jl
+++ b/src/SkewLinearAlgebra.jl
@@ -15,10 +15,8 @@ export
     JMatrix,
     #functions
     isskewhermitian,
-    isapproxskewhermitian,
     skewhermitian,
     skewhermitian!,
-    to_symtridiagonal,
     pfaffian,
     pfaffian!,
     logabspfaffian,

--- a/src/skewhermitian.jl
+++ b/src/skewhermitian.jl
@@ -89,16 +89,6 @@ end
 isskewhermitian(A::SkewHermitian) = true
 isskewhermitian(a::Number) = a == -a'
 
-function isapproxskewhermitian(A::AbstractMatrix{<:Number})
-    axes(A,1) == axes(A,2) || throw(ArgumentError("axes $(axes(A,1)) and $(axex(A,2)) do not match"))
-    @inbounds for i in axes(A,1)
-        for j = firstindex(A, 1):i
-            A[i,j] ≈ -A[j,i]' || return false
-        end
-    end
-    return true
-end
-
 """
     skewhermitian!(A)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ using Test
 
 Random.seed!(314159) # use same pseudorandom stream for every test
 
+isapproxskewhermitian(A) = A ≈ -A'
+
 @testset "README.md" begin # test from the README examples
     A = [0 2 -7 4; -2 0 -8 3; 7 8 0 1;-4 -3 -1 0]
     @test isskewhermitian(A)
@@ -218,7 +220,7 @@ end
             @test exp(log(A)) ≈ A
         end
         if issuccess(lu(cos(B), check = false)) && issuccess(lu(det(exp(2A)+I), check = false))
-            if isapproxskewhermitian(tan(B)) && isapproxskewhermitian(tanh(B)) 
+            if isapproxskewhermitian(tan(B)) && isapproxskewhermitian(tanh(B))
                 @test tan(B) ≈ tan(A)
                 @test tanh(B) ≈ tanh(A)
             end
@@ -231,7 +233,7 @@ end
                 end
             catch
             end
-        end 
+        end
     end
     for T in (Int32 ,Float32,Float64,ComplexF32), n in [2, 10, 11]
         if T<:Integer
@@ -257,7 +259,7 @@ end
             @test exp(log(A)) ≈ A
         end
         if issuccess(lu(cos(B), check = false)) && issuccess(lu(det(exp(2A)+I), check = false))
-            if isapproxskewhermitian(tan(B)) && isapproxskewhermitian(tanh(B)) 
+            if isapproxskewhermitian(tan(B)) && isapproxskewhermitian(tanh(B))
                 @test tan(B) ≈ tan(A)
                 @test tanh(B) ≈ tanh(A)
             end


### PR DESCRIPTION
In #109, you added an `isapproxskewhermitian` that checks `A[i,j] ≈ -A[j,i]'` elementwise.  This is generally a bad way to compare arrays.  Instead, you generally want to compare whole-array norms, e.g. compare ‖A+A'‖ to ‖A‖.  For example, this result makes little sense:
```jl
julia> A = [0 1 1e-16; -1 0 1; 0 -1 0]
3×3 Matrix{Float64}:
  0.0   1.0  1.0e-16
 -1.0   0.0  1.0
  0.0  -1.0  0.0

julia> isapproxskewhermitian(A)
false

julia> norm(A+A') / norm(A)
7.071067811865474e-17
```
Since this function is only used for testing, it makes more sense to just define `isapproxskewhermitian(A) = A ≈ -A'` (where `≈` on arrays compares whole-array norms) in `runtests.jl`, rather than trying to export something.

I also removed the export for `to_symtridiagonal`, which is mostly an internal implementation detail and is not documented.  If there is some need for this we could always document it and export it.  (It would make sense to add documentation for it and other internal functions anyway, of course.)