### PR TITLE
add pivot argument for skew Cholesky

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,8 @@ version = "1.0.1"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-julia = "1.6"
-LinearAlgebra = "1.6"
+julia = "1.10"
+LinearAlgebra = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/SkewLinearAlgebra.jl
+++ b/src/SkewLinearAlgebra.jl
@@ -12,6 +12,7 @@ export
     SkewHermitian,
     SkewHermTridiagonal,
     SkewCholesky,
+    SkewCholeskyNoPivot,
     JMatrix,
     #functions
     isskewhermitian,

--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -18,38 +18,18 @@ Construct a `SkewCholesky` structure from the `UpperTriangular`
 matrix `R` and the permutation vector `p`. A matrix `J` of type `JMatrix`
 is build calling this function.
 The `SkewCholesky` structure has three arguments: `R`,`J` and `p`.
+`p` may be `Base.OneTo(n)`, which indicates no pivoting was used.
 """
 function SkewCholesky(R::UpperTriangular{<:T},p::AbstractVector{<:Integer}) where {T<:Real}
     n = size(R, 1)
     return SkewCholesky{T,typeof(R),JMatrix{T,+1},typeof(p)}(R, JMatrix{T,+1}(n), p)
 end
 
-struct SkewCholeskyNoPivot{T,R<:UpperTriangular{<:T},J<:JMatrix{<:T}}
-    R::R #Uppertriangular matrix
-    J::J # Block diagonal skew-symmetric matrix of type JMatrix
-
-    function SkewCholeskyNoPivot{T,R,J}(Rm,Jm) where {T,R,J}
-        LA.require_one_based_indexing(Rm)
-        new{T,R,J}(Rm,Jm)
-    end
-end
-
-"""
-    SkewCholeskyNoPivot(R)
-
-Construct a `SkewCholeskyNoPivot` structure from the `UpperTriangular`
-matrix `R`. A matrix `J` of type `JMatrix` is build calling this function.
-The `SkewCholeskyNoPivot` structure has two arguments: `R` and `J`.
-"""
-function SkewCholeskyNoPivot(R::UpperTriangular{<:T}) where {T<:Real}
-    n = size(R, 1)
-    return SkewCholeskyNoPivot{T,typeof(R),JMatrix{T,+1}}(R, JMatrix{T,+1}(n))
-end
-
-function _skewchol_nopivot!(A::SkewHermitian{<:Real})
+function _skewchol!(A::SkewHermitian{<:Real}, ::NoPivot)
     B = A.data
     m = size(B,1)
-    m == 1 && return
+    P = Base.OneTo(m)
+    m == 1 && return P
     J2 = similar(B,2,2)
     J2[1,1] = 0; J2[2,1] = -1; J2[1,2] = 1; J2[2,2] = 0
     tempM = similar(B,2,m-2)
@@ -72,10 +52,10 @@ function _skewchol_nopivot!(A::SkewHermitian{<:Real})
         @views mul!(tempM[:,1:l], J2, B[j2-1:j2,j2+1:m])
         @views mul!(B[j2+1:m,j2+1:m], transpose(B[j2-1:j2,j2+1:m]), tempM[:,1:l],-1,1)
     end
-    return
+    return P
 end
 
-function _skewchol!(A::SkewHermitian{<:Real})
+function _skewchol!(A::SkewHermitian{<:Real}, ::RowMaximum)
     B = A.data
     tol = 1e-15 * norm(B)
     m = size(B,1)
@@ -131,19 +111,12 @@ function _skewchol!(A::SkewHermitian{<:Real})
 end
 copyeigtype(A::AbstractMatrix) = copyto!(similar(A, LA.eigtype(eltype(A))), A)
 
-@views function skewchol!(A::SkewHermitian, ::LA.RowMaximum)
-    P = _skewchol!(A)
+@views function skewchol!(A::SkewHermitian, pivot::Union{RowMaximum,NoPivot}=RowMaximum())
+    P = _skewchol!(A, pivot)
     return SkewCholesky(UpperTriangular(A.data), P)
 end
 
-@views function skewchol!(A::SkewHermitian, ::LA.NoPivot)
-    _skewchol_nopivot!(A)
-    return SkewCholeskyNoPivot(UpperTriangular(A.data))
-end
-
-skewchol!(A::SkewHermitian) = skewchol!(A, LA.RowMaximum())
-
-skewchol(A::SkewHermitian, pivot::Union{LA.RowMaximum,LA.NoPivot}=LA.RowMaximum()) =
+skewchol(A::SkewHermitian, pivot::Union{RowMaximum,NoPivot}=RowMaximum()) =
     skewchol!(copyeigtype(A), pivot)
 
 """
@@ -151,26 +124,23 @@ skewchol!(A, [pivot])
 
 Similar to [`skewchol`](@ref), but overwrites `A` in-place with intermediate calculations.
 """
-skewchol!(A::AbstractMatrix, pivot::Union{LA.RowMaximum,LA.NoPivot}=LA.RowMaximum()) =
+skewchol!(A::AbstractMatrix, pivot::Union{RowMaximum,NoPivot}=RowMaximum()) =
     @views skewchol!(SkewHermitian(A), pivot)
 
 """
     skewchol(A, [pivot::Union{RowMaximum,NoPivot}])
 
 Computes a Cholesky-like factorization of the real skew-symmetric matrix `A`.
-The function returns a `SkewCholesky` or `SkewCholeskyNoPivot` structure
-depending on whether pivoting is used.
+The function returns a `SkewCholesky` factorization object.
 
 With `RowMaximum()` (default), the result is a `SkewCholesky` with fields `R`, `J`, `p`,
-such that `S.R'*S.J*S.R = A[S.p,S.p]`.
-
-With `NoPivot()`, the result is a `SkewCholeskyNoPivot` with fields `R`, `J`,
-such that `S.R'*S.J*S.R = A`.
+such that `S.R'*S.J*S.R = A[S.p,S.p]`. Pivoting can be disabled by passing `NoPivot()`
+as the second argument, in which case `S.p` is `Base.OneTo(n)`, such that `S.R'*S.J*S.R = A`.
 
 This factorization (and the underlying algorithm) is described in from P. Benner et al,
 "[Cholesky-like factorizations of skew-symmetric matrices](https://etna.ricam.oeaw.ac.at/vol.11.2000/pp85-93.dir/pp85-93.pdf)"(2000).
 """
-function skewchol(A::AbstractMatrix, pivot::Union{LA.RowMaximum,LA.NoPivot}=LA.RowMaximum())
+function skewchol(A::AbstractMatrix, pivot::Union{RowMaximum,NoPivot}=RowMaximum())
     isskewhermitian(A) || throw(ArgumentError("Pfaffian requires a skew-Hermitian matrix"))
     return skewchol!(SkewHermitian(copyeigtype(A)), pivot)
 end

--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -22,11 +22,61 @@ The `SkewCholesky` structure has three arguments: `R`,`J` and `p`.
 function SkewCholesky(R::UpperTriangular{<:T},p::AbstractVector{<:Integer}) where {T<:Real}
     n = size(R, 1)
     return SkewCholesky{T,typeof(R),JMatrix{T,+1},typeof(p)}(R, JMatrix{T,+1}(n), p)
+end
 
+struct SkewCholeskyNoPivot{T,R<:UpperTriangular{<:T},J<:JMatrix{<:T}}
+    R::R #Uppertriangular matrix
+    J::J # Block diagonal skew-symmetric matrix of type JMatrix
+
+    function SkewCholeskyNoPivot{T,R,J}(Rm,Jm) where {T,R,J}
+        LA.require_one_based_indexing(Rm)
+        new{T,R,J}(Rm,Jm)
+    end
+end
+
+"""
+    SkewCholeskyNoPivot(R)
+
+Construct a `SkewCholeskyNoPivot` structure from the `UpperTriangular`
+matrix `R`. A matrix `J` of type `JMatrix` is build calling this function.
+The `SkewCholeskyNoPivot` structure has two arguments: `R` and `J`.
+"""
+function SkewCholeskyNoPivot(R::UpperTriangular{<:T}) where {T<:Real}
+    n = size(R, 1)
+    return SkewCholeskyNoPivot{T,typeof(R),JMatrix{T,+1}}(R, JMatrix{T,+1}(n))
+end
+
+function _skewchol_nopivot!(A::SkewHermitian{<:Real})
+    B = A.data
+    m = size(B,1)
+    m == 1 && return
+    J2 = similar(B,2,2)
+    J2[1,1] = 0; J2[2,1] = -1; J2[1,2] = 1; J2[2,2] = 0
+    tempM = similar(B,2,m-2)
+    for j = 1:m÷2
+        j2 = 2*j
+        l = m-j2
+        # Without pivoting, we need to carefully handle the case [0 -a; a 0]
+        # Set B[j2-1:j2, j2-1:j2] to Diagonal([√a, -√a])
+        s = sign(B[j2-1,j2])
+        r = sqrt(abs(B[j2-1,j2]))
+        B[j2-1,j2-1] = r
+        B[j2,j2] = s*r
+        B[j2-1,j2] = 0
+        # In the s=-1 case, B[j2-1:j2, j2+1:m] needs to be set to Diagonal([1/√a, -1/√a]) * J * B[j2-1:j2, j2+1:m]
+        # which is equivalent to 1/√a * [0 -1; -1 0] * B[j2-1:j2, j2+1:m], so we temporarily set J2[1,2] = -1
+        J2[1,2] = s
+        @views mul!(tempM[:,1:l], J2, B[j2-1:j2,j2+1:m])
+        J2[1,2] = 1
+        B[j2-1:j2,j2+1:m] .= (-1/r) .* tempM[:,1:l]
+        @views mul!(tempM[:,1:l], J2, B[j2-1:j2,j2+1:m])
+        @views mul!(B[j2+1:m,j2+1:m], transpose(B[j2-1:j2,j2+1:m]), tempM[:,1:l],-1,1)
+    end
+    return
 end
 
 function _skewchol!(A::SkewHermitian{<:Real})
-    @views B = A.data
+    B = A.data
     tol = 1e-15 * norm(B)
     m = size(B,1)
     m == 1 && return [1]
@@ -81,35 +131,48 @@ function _skewchol!(A::SkewHermitian{<:Real})
 end
 copyeigtype(A::AbstractMatrix) = copyto!(similar(A, LA.eigtype(eltype(A))), A)
 
-@views function skewchol!(A::SkewHermitian)
+@views function skewchol!(A::SkewHermitian, ::LA.RowMaximum)
     P = _skewchol!(A)
     return SkewCholesky(UpperTriangular(A.data), P)
 end
 
-skewchol(A::SkewHermitian) = skewchol!(copyeigtype(A))
+@views function skewchol!(A::SkewHermitian, ::LA.NoPivot)
+    _skewchol_nopivot!(A)
+    return SkewCholeskyNoPivot(UpperTriangular(A.data))
+end
+
+skewchol!(A::SkewHermitian) = skewchol!(A, LA.RowMaximum())
+
+skewchol(A::SkewHermitian, pivot::Union{LA.RowMaximum,LA.NoPivot}=LA.RowMaximum()) =
+    skewchol!(copyeigtype(A), pivot)
 
 """
-skewchol!(A)
+skewchol!(A, [pivot])
 
-Similar to [`skewchol!`](@ref), but overwrites `A` in-place with intermediate calculations.
+Similar to [`skewchol`](@ref), but overwrites `A` in-place with intermediate calculations.
 """
-skewchol!(A::AbstractMatrix) = @views  skewchol!(SkewHermitian(A))
+skewchol!(A::AbstractMatrix, pivot::Union{LA.RowMaximum,LA.NoPivot}=LA.RowMaximum()) =
+    @views skewchol!(SkewHermitian(A), pivot)
 
 """
-    skewchol(A)
+    skewchol(A, [pivot::Union{RowMaximum,NoPivot}])
 
 Computes a Cholesky-like factorization of the real skew-symmetric matrix `A`.
-The function returns a `SkewCholesky` structure composed of three fields:
-`R`,`J`,`p`. `R` is `UpperTriangular`, `J` is a `JMatrix`,
-`p` is an array of integers. Let `S` be the returned structure, then the factorization
-is such that `S.R'*S.J*S.R = A[S.p,S.p]`
+The function returns a `SkewCholesky` or `SkewCholeskyNoPivot` structure
+depending on whether pivoting is used.
+
+With `RowMaximum()` (default), the result is a `SkewCholesky` with fields `R`, `J`, `p`,
+such that `S.R'*S.J*S.R = A[S.p,S.p]`.
+
+With `NoPivot()`, the result is a `SkewCholeskyNoPivot` with fields `R`, `J`,
+such that `S.R'*S.J*S.R = A`.
 
 This factorization (and the underlying algorithm) is described in from P. Benner et al,
 "[Cholesky-like factorizations of skew-symmetric matrices](https://etna.ricam.oeaw.ac.at/vol.11.2000/pp85-93.dir/pp85-93.pdf)"(2000).
 """
-function skewchol(A::AbstractMatrix)
+function skewchol(A::AbstractMatrix, pivot::Union{LA.RowMaximum,LA.NoPivot}=LA.RowMaximum())
     isskewhermitian(A) || throw(ArgumentError("Pfaffian requires a skew-Hermitian matrix"))
-    return skewchol!(SkewHermitian(copyeigtype(A)))
+    return skewchol!(SkewHermitian(copyeigtype(A)), pivot)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -442,9 +442,17 @@ end
         end
         C = skewchol(A)
         @test transpose(C.R) * C.J *C.R ≈ A.data[C.p, C.p]
+        C = skewchol(A, RowMaximum())
+        @test transpose(C.R) * C.J *C.R ≈ A.data[C.p, C.p]
+        C = skewchol(A, NoPivot())
+        @test transpose(C.R) * C.J *C.R ≈ A.data
         B = Matrix(A)
         C = skewchol(B)
         @test transpose(C.R)* C.J *C.R ≈ B[C.p, C.p]
+        C = skewchol(B, RowMaximum())
+        @test transpose(C.R)* C.J *C.R ≈ B[C.p, C.p]
+        C = skewchol(B, NoPivot())
+        @test transpose(C.R)* C.J *C.R ≈ B
     end
 end
 


### PR DESCRIPTION
closes #151

Initial sketch written with Copilot, but reviewed and verified carefully
to correctly handle edge cases. I'd appreciate a second opinion on the
solution I came up with for the case of negative Pfaffians on the block
diagonal. There is no special handling for the singular case, without
pivoting, the result will simply blow up. I guess we could throw a
`SingularException`, but not sure it's worth it?
